### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cdktest.yml
+++ b/.github/workflows/cdktest.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   cdk-synth:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/sample-serverless-dbless-rag-on-aws/security/code-scanning/1](https://github.com/aws-samples/sample-serverless-dbless-rag-on-aws/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/cdktest.yml` so the workflow does not inherit potentially broad defaults.  
Best fix here (without changing functionality) is to set workflow-level permissions to read-only for repository contents:

- File: `.github/workflows/cdktest.yml`
- Region: near the top-level keys (`name`, `on`, `jobs`)
- Add:
  - `permissions:`
  - `contents: read`

This is sufficient for `actions/checkout` and read-only workflow operations shown in this snippet, and applies to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
